### PR TITLE
smtk-repo: removed GPG signing from smtk-testing.

### DIFF
--- a/smtk-repo/SOURCES/smtk-testing.repo
+++ b/smtk-repo/SOURCES/smtk-testing.repo
@@ -5,8 +5,7 @@ mirrorlist=file:///usr/local/share/smtk-repo/testing/$basearch.mirrors
 failovermethod=priority
 priority=1
 enabled=0
-gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-SIMTECH
+gpgcheck=0
 
 [smtk-testing-i386]
 name=Simtech Release (Stable) Repo for RHEL/CentOS - $basearch
@@ -15,8 +14,7 @@ mirrorlist=file:///usr/local/share/smtk-repo/testing/i386.mirrors
 failovermethod=priority
 priority=1
 enabled=0
-gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-SIMTECH
+gpgcheck=0
 
 [smtk-testing-i686]
 name=Simtech Release (Stable) Repo for RHEL/CentOS - $basearch
@@ -25,8 +23,7 @@ mirrorlist=file:///usr/local/share/smtk-repo/testing/i686.mirrors
 failovermethod=priority
 priority=1
 enabled=0
-gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-SIMTECH
+gpgcheck=0
 
 [smtk-testing-x64]
 name=SIMTECH Testing (Unstable) Repo for RHEL/CentOS - $basearch
@@ -35,8 +32,7 @@ mirrorlist=file:///usr/local/share/smtk-repo/testing/x86_64.mirrors
 failovermethod=priority
 priority=1
 enabled=0
-gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-SIMTECH
+gpgcheck=0
 
 [smtk-testing-src]
 name=SIMTECH Testing (Unstable) Repo for RHEL/CentOS - $basearch
@@ -45,5 +41,4 @@ mirrorlist=file:///usr/local/share/smtk-repo/testing/SRPMS.mirrors
 failovermethod=priority
 priority=1
 enabled=0
-gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-SIMTECH
+gpgcheck=0


### PR DESCRIPTION
We used to unable install packages from smtk-testing.
